### PR TITLE
Fix output syntax

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,4 +19,4 @@ runs:
         cd ${{ inputs.path }}
         folders=$(tree -J -d -L 1 | jq -c '.[0].contents | map(.name)')
         echo $folders
-        echo "{folders}={$folders}" >> $GITHUB_OUTPUT
+        echo "folders=$folders" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Apparently, I used the wrong syntax when using the new `$GITHUB-OUTPUT` environment file.